### PR TITLE
feat: MVP-2 献血ルーム マップ表示

### DIFF
--- a/api/internal/handler/center_test.go
+++ b/api/internal/handler/center_test.go
@@ -1,0 +1,391 @@
+package handler_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/akaitigo/kenketsu-plus/api/internal/handler"
+	"github.com/akaitigo/kenketsu-plus/api/internal/model"
+	"github.com/akaitigo/kenketsu-plus/api/internal/repository"
+	"github.com/akaitigo/kenketsu-plus/api/internal/service"
+)
+
+func newTestRouter() http.Handler {
+	return handler.NewRouter(
+		repository.NewCenterRepository(),
+		repository.NewDonationRepository(),
+		repository.NewInventoryRepository(),
+		repository.NewSubscriptionRepository(),
+		service.NewDonationCalculator(),
+	)
+}
+
+func createCenter(t *testing.T, router http.Handler, center model.DonationCenter) model.DonationCenter {
+	t.Helper()
+
+	body, err := json.Marshal(center)
+	if err != nil {
+		t.Fatalf("failed to marshal center: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/centers", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var created model.DonationCenter
+	if err := json.NewDecoder(rec.Body).Decode(&created); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	return created
+}
+
+func TestListCenters_Empty(t *testing.T) {
+	t.Parallel()
+
+	router := newTestRouter()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/centers", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	var centers []model.DonationCenter
+	if err := json.NewDecoder(rec.Body).Decode(&centers); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(centers) != 0 {
+		t.Errorf("expected 0 centers, got %d", len(centers))
+	}
+}
+
+func TestListCenters_WithData(t *testing.T) {
+	t.Parallel()
+
+	router := newTestRouter()
+
+	createCenter(t, router, model.DonationCenter{
+		Name:           "Shibuya Center",
+		Address:        "Shibuya, Tokyo",
+		Lat:            35.6580,
+		Lng:            139.7016,
+		Capacity:       50,
+		AvailableSlots: 10,
+	})
+
+	createCenter(t, router, model.DonationCenter{
+		Name:           "Shinjuku Center",
+		Address:        "Shinjuku, Tokyo",
+		Lat:            35.6938,
+		Lng:            139.7034,
+		Capacity:       30,
+		AvailableSlots: 5,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/centers", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	var centers []model.DonationCenter
+	if err := json.NewDecoder(rec.Body).Decode(&centers); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(centers) != 2 {
+		t.Errorf("expected 2 centers, got %d", len(centers))
+	}
+}
+
+func TestCreateCenter_Success(t *testing.T) {
+	t.Parallel()
+
+	router := newTestRouter()
+
+	input := model.DonationCenter{
+		Name:           "Ikebukuro Center",
+		Address:        "Ikebukuro, Tokyo",
+		Lat:            35.7295,
+		Lng:            139.7109,
+		Capacity:       40,
+		AvailableSlots: 15,
+	}
+
+	created := createCenter(t, router, input)
+
+	if created.ID == "" {
+		t.Error("expected ID to be set")
+	}
+	if created.Name != input.Name {
+		t.Errorf("expected name %q, got %q", input.Name, created.Name)
+	}
+	if created.Address != input.Address {
+		t.Errorf("expected address %q, got %q", input.Address, created.Address)
+	}
+	if created.Status != model.CenterStatusOpen {
+		t.Errorf("expected status %q, got %q", model.CenterStatusOpen, created.Status)
+	}
+	if created.CreatedAt.IsZero() {
+		t.Error("expected createdAt to be set")
+	}
+}
+
+func TestCreateCenter_ValidationError_MissingName(t *testing.T) {
+	t.Parallel()
+
+	router := newTestRouter()
+
+	input := model.DonationCenter{
+		Address:        "Somewhere",
+		Lat:            35.0,
+		Lng:            139.0,
+		Capacity:       10,
+		AvailableSlots: 5,
+	}
+
+	body, err := json.Marshal(input)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/centers", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", rec.Code)
+	}
+}
+
+func TestCreateCenter_ValidationError_InvalidLat(t *testing.T) {
+	t.Parallel()
+
+	router := newTestRouter()
+
+	input := model.DonationCenter{
+		Name:           "Bad Center",
+		Address:        "Nowhere",
+		Lat:            91.0,
+		Lng:            139.0,
+		Capacity:       10,
+		AvailableSlots: 5,
+	}
+
+	body, err := json.Marshal(input)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/centers", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", rec.Code)
+	}
+}
+
+func TestCreateCenter_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	router := newTestRouter()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/centers", bytes.NewReader([]byte("not json")))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", rec.Code)
+	}
+}
+
+func TestGetCenterByID_Success(t *testing.T) {
+	t.Parallel()
+
+	router := newTestRouter()
+
+	created := createCenter(t, router, model.DonationCenter{
+		Name:           "Tokyo Center",
+		Address:        "Chiyoda, Tokyo",
+		Lat:            35.6812,
+		Lng:            139.7671,
+		Capacity:       60,
+		AvailableSlots: 20,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/centers/"+created.ID, nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	var fetched model.DonationCenter
+	if err := json.NewDecoder(rec.Body).Decode(&fetched); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if fetched.ID != created.ID {
+		t.Errorf("expected ID %q, got %q", created.ID, fetched.ID)
+	}
+	if fetched.Name != created.Name {
+		t.Errorf("expected name %q, got %q", created.Name, fetched.Name)
+	}
+}
+
+func TestGetCenterByID_NotFound(t *testing.T) {
+	t.Parallel()
+
+	router := newTestRouter()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/centers/nonexistent-id", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected status 404, got %d", rec.Code)
+	}
+}
+
+func TestListCenters_DistanceFilter(t *testing.T) {
+	t.Parallel()
+
+	router := newTestRouter()
+
+	// Shibuya (near the query point)
+	createCenter(t, router, model.DonationCenter{
+		Name:           "Shibuya Center",
+		Address:        "Shibuya, Tokyo",
+		Lat:            35.6580,
+		Lng:            139.7016,
+		Capacity:       50,
+		AvailableSlots: 10,
+	})
+
+	// Osaka (far away)
+	createCenter(t, router, model.DonationCenter{
+		Name:           "Osaka Center",
+		Address:        "Osaka",
+		Lat:            34.6937,
+		Lng:            135.5023,
+		Capacity:       30,
+		AvailableSlots: 5,
+	})
+
+	// Query near Shibuya with 5km radius
+	req := httptest.NewRequest(http.MethodGet, "/api/centers?lat=35.66&lng=139.70&radius=5", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	var centers []model.DonationCenter
+	if err := json.NewDecoder(rec.Body).Decode(&centers); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(centers) != 1 {
+		t.Fatalf("expected 1 center within radius, got %d", len(centers))
+	}
+
+	if centers[0].Name != "Shibuya Center" {
+		t.Errorf("expected Shibuya Center, got %q", centers[0].Name)
+	}
+}
+
+func TestListCenters_DistanceFilter_InvalidLat(t *testing.T) {
+	t.Parallel()
+
+	router := newTestRouter()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/centers?lat=abc&lng=139.70", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", rec.Code)
+	}
+}
+
+func TestListCenters_DistanceFilter_InvalidLng(t *testing.T) {
+	t.Parallel()
+
+	router := newTestRouter()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/centers?lat=35.66&lng=abc", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", rec.Code)
+	}
+}
+
+func TestListCenters_DistanceFilter_InvalidRadius(t *testing.T) {
+	t.Parallel()
+
+	router := newTestRouter()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/centers?lat=35.66&lng=139.70&radius=abc", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", rec.Code)
+	}
+}
+
+func TestListCenters_DistanceFilter_DefaultRadius(t *testing.T) {
+	t.Parallel()
+
+	router := newTestRouter()
+
+	// Shinjuku (about 4km from query point)
+	createCenter(t, router, model.DonationCenter{
+		Name:           "Shinjuku Center",
+		Address:        "Shinjuku, Tokyo",
+		Lat:            35.6938,
+		Lng:            139.7034,
+		Capacity:       30,
+		AvailableSlots: 5,
+	})
+
+	// Query without radius param (default = 10km)
+	req := httptest.NewRequest(http.MethodGet, "/api/centers?lat=35.66&lng=139.70", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	var centers []model.DonationCenter
+	if err := json.NewDecoder(rec.Body).Decode(&centers); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(centers) != 1 {
+		t.Errorf("expected 1 center within default radius, got %d", len(centers))
+	}
+}

--- a/frontend/src/app/map/page.tsx
+++ b/frontend/src/app/map/page.tsx
@@ -1,0 +1,31 @@
+import DonationMap from "@/components/DonationMap";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+	title: "献血ルームマップ | Kenketsu-Plus",
+	description: "近くの献血ルームをマップで確認できます",
+};
+
+export default function MapPage() {
+	return (
+		<main style={{ height: "100vh", display: "flex", flexDirection: "column" }}>
+			<header
+				style={{
+					padding: "12px 16px",
+					borderBottom: "1px solid #e5e7eb",
+					display: "flex",
+					alignItems: "center",
+					gap: 12,
+				}}
+			>
+				<a href="/" style={{ textDecoration: "none", color: "#6b7280", fontSize: 14 }}>
+					&larr; ホーム
+				</a>
+				<h1 style={{ margin: 0, fontSize: 18, fontWeight: 600 }}>献血ルームマップ</h1>
+			</header>
+			<div style={{ flex: 1, position: "relative" }}>
+				<DonationMap />
+			</div>
+		</main>
+	);
+}

--- a/frontend/src/components/DonationMap.test.ts
+++ b/frontend/src/components/DonationMap.test.ts
@@ -1,0 +1,96 @@
+import type { DonationCenter } from "@/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+beforeEach(() => {
+	mockFetch.mockReset();
+});
+
+const sampleCenter: DonationCenter = {
+	id: "center-1",
+	name: "Shibuya Center",
+	address: "Shibuya, Tokyo",
+	lat: 35.658,
+	lng: 139.7016,
+	capacity: 50,
+	availableSlots: 10,
+	status: "open",
+	createdAt: "2026-01-01T00:00:00Z",
+	updatedAt: "2026-01-01T00:00:00Z",
+};
+
+describe("DonationMap data fetching", () => {
+	it("fetches centers from the API", async () => {
+		const centers: DonationCenter[] = [sampleCenter];
+
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: () => Promise.resolve(centers),
+		});
+
+		const { api } = await import("@/lib/api");
+		const result = await api.get<DonationCenter[]>("/api/centers");
+
+		expect(result).toEqual(centers);
+		expect(mockFetch).toHaveBeenCalledWith(
+			"http://localhost:8080/api/centers",
+			expect.objectContaining({
+				headers: { "Content-Type": "application/json" },
+			}),
+		);
+	});
+
+	it("handles empty center list", async () => {
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: () => Promise.resolve([]),
+		});
+
+		const { api } = await import("@/lib/api");
+		const result = await api.get<DonationCenter[]>("/api/centers");
+
+		expect(result).toEqual([]);
+	});
+
+	it("handles API error", async () => {
+		mockFetch.mockResolvedValueOnce({
+			ok: false,
+			status: 500,
+			text: () => Promise.resolve("Internal Server Error"),
+		});
+
+		const { api, ApiError } = await import("@/lib/api");
+
+		await expect(api.get<DonationCenter[]>("/api/centers")).rejects.toThrow(ApiError);
+	});
+
+	it("DonationCenter type has required fields", () => {
+		expect(sampleCenter.id).toBe("center-1");
+		expect(sampleCenter.name).toBe("Shibuya Center");
+		expect(sampleCenter.lat).toBe(35.658);
+		expect(sampleCenter.lng).toBe(139.7016);
+		expect(sampleCenter.status).toBe("open");
+		expect(sampleCenter.availableSlots).toBe(10);
+		expect(sampleCenter.capacity).toBe(50);
+	});
+
+	it("fetches centers with distance filter", async () => {
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: () => Promise.resolve([sampleCenter]),
+		});
+
+		const { api } = await import("@/lib/api");
+		const result = await api.get<DonationCenter[]>("/api/centers?lat=35.66&lng=139.70&radius=5");
+
+		expect(result).toHaveLength(1);
+		expect(mockFetch).toHaveBeenCalledWith(
+			"http://localhost:8080/api/centers?lat=35.66&lng=139.70&radius=5",
+			expect.objectContaining({
+				headers: { "Content-Type": "application/json" },
+			}),
+		);
+	});
+});

--- a/frontend/src/components/DonationMap.tsx
+++ b/frontend/src/components/DonationMap.tsx
@@ -1,0 +1,40 @@
+"use client";
+import dynamic from "next/dynamic";
+import { useCenters } from "./useCenters";
+
+const DonationMapContent = dynamic(() => import("./DonationMapContent"), {
+	ssr: false,
+	loading: () => (
+		<div style={{ height: "100%", display: "flex", alignItems: "center", justifyContent: "center" }}>
+			<p>マップを読み込んでいます...</p>
+		</div>
+	),
+});
+
+function CenteredMessage({ children }: { children: React.ReactNode }) {
+	return (
+		<div style={{ height: "100%", display: "flex", alignItems: "center", justifyContent: "center" }}>{children}</div>
+	);
+}
+
+export default function DonationMap() {
+	const { centers, error, loading } = useCenters();
+
+	if (loading) {
+		return (
+			<CenteredMessage>
+				<p>読み込み中...</p>
+			</CenteredMessage>
+		);
+	}
+
+	if (error) {
+		return (
+			<CenteredMessage>
+				<p style={{ color: "#dc2626" }}>{error}</p>
+			</CenteredMessage>
+		);
+	}
+
+	return <DonationMapContent centers={centers} />;
+}

--- a/frontend/src/components/DonationMapContent.tsx
+++ b/frontend/src/components/DonationMapContent.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import type { DonationCenter } from "@/types";
+import "leaflet/dist/leaflet.css";
+import { type Icon, icon } from "leaflet";
+import { MapContainer, Marker, Popup, TileLayer } from "react-leaflet";
+
+const TOKYO_CENTER: [number, number] = [35.6812, 139.7671];
+const DEFAULT_ZOOM = 12;
+
+const defaultIcon: Icon = icon({
+	iconUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png",
+	iconRetinaUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png",
+	shadowUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png",
+	iconSize: [25, 41],
+	iconAnchor: [12, 41],
+	popupAnchor: [1, -34],
+	shadowSize: [41, 41],
+});
+
+function statusLabel(status: DonationCenter["status"]): string {
+	switch (status) {
+		case "open":
+			return "受付中";
+		case "closed":
+			return "受付終了";
+		case "full":
+			return "満員";
+		default:
+			return "不明";
+	}
+}
+
+function statusColor(status: DonationCenter["status"]): string {
+	switch (status) {
+		case "open":
+			return "#16a34a";
+		case "closed":
+			return "#dc2626";
+		case "full":
+			return "#ea580c";
+		default:
+			return "#6b7280";
+	}
+}
+
+interface DonationMapContentProps {
+	centers: DonationCenter[];
+}
+
+export default function DonationMapContent({ centers }: DonationMapContentProps) {
+	return (
+		<MapContainer
+			center={TOKYO_CENTER}
+			zoom={DEFAULT_ZOOM}
+			scrollWheelZoom={true}
+			style={{ height: "100%", width: "100%" }}
+		>
+			<TileLayer
+				attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+				url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+			/>
+			{centers.map((center) => (
+				<Marker key={center.id} position={[center.lat, center.lng]} icon={defaultIcon}>
+					<Popup>
+						<div style={{ minWidth: 180 }}>
+							<h3 style={{ margin: "0 0 4px 0", fontSize: 14, fontWeight: 600 }}>{center.name}</h3>
+							<p style={{ margin: "0 0 4px 0", fontSize: 12, color: "#4b5563" }}>{center.address}</p>
+							<p style={{ margin: "0 0 4px 0", fontSize: 12 }}>
+								<span
+									style={{
+										color: statusColor(center.status),
+										fontWeight: 600,
+									}}
+								>
+									{statusLabel(center.status)}
+								</span>
+							</p>
+							<p style={{ margin: 0, fontSize: 12, color: "#6b7280" }}>
+								空き: {center.availableSlots} / {center.capacity}
+							</p>
+						</div>
+					</Popup>
+				</Marker>
+			))}
+		</MapContainer>
+	);
+}

--- a/frontend/src/components/useCenters.ts
+++ b/frontend/src/components/useCenters.ts
@@ -1,0 +1,54 @@
+"use client";
+
+import { api } from "@/lib/api";
+import type { DonationCenter } from "@/types";
+import { useEffect, useState } from "react";
+
+interface UseCentersResult {
+	centers: DonationCenter[];
+	error: string | null;
+	loading: boolean;
+}
+
+function extractErrorMessage(err: unknown): string {
+	if (err instanceof Error) {
+		return err.message;
+	}
+	return "データの取得に失敗しました";
+}
+
+export function useCenters(): UseCentersResult {
+	const [centers, setCenters] = useState<DonationCenter[]>([]);
+	const [error, setError] = useState<string | null>(null);
+	const [loading, setLoading] = useState(true);
+
+	useEffect(() => {
+		let cancelled = false;
+
+		async function fetchCenters() {
+			try {
+				const data = await api.get<DonationCenter[]>("/api/centers");
+				if (!cancelled) {
+					setCenters(data ?? []);
+					setError(null);
+				}
+			} catch (err: unknown) {
+				if (!cancelled) {
+					setError(extractErrorMessage(err));
+				}
+			} finally {
+				if (!cancelled) {
+					setLoading(false);
+				}
+			}
+		}
+
+		void fetchCenters();
+
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	return { centers, error, loading };
+}


### PR DESCRIPTION
## Summary
- Go API の CenterHandler に包括的テストを追加（13テストケース: 空リスト、データあり、作成成功/バリデーションエラー、GetByID成功/404、距離フィルタ各種）
- Leaflet.js マップコンポーネントを実装（dynamic importでSSR回避、マーカー+Popup表示）
- `/map` ページを追加（献血ルーム一覧をマップ上に表示）
- フロントエンドテスト追加（5テストケース: APIフェッチ、空リスト、エラーハンドリング、距離フィルタ）

## Test plan
- [x] Go API テスト: `go test -race ./...` 全パス
- [x] Frontend テスト: `vitest run` 全パス (8 tests)
- [x] TypeScript 型チェック: `tsc --noEmit` エラーなし
- [x] Biome lint/format: warning なし（MVP-2スコープ内）
- [x] Go ビルド: `go build -trimpath ./...` 成功
- [x] Frontend ビルド: `next build` 成功

Closes #2