### PR TITLE
feat: テスト拡充+PostgreSQLインテグレーション+VAPID/haversine整備 (#23 #22 #25 #24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,24 @@ jobs:
     defaults:
       run:
         working-directory: api
+    services:
+      # PostgreSQL service for the integration tests, which are skipped when
+      # DATABASE_URL is unset (e.g. a plain local `go test`).
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: kenketsu
+          POSTGRES_PASSWORD: kenketsu
+          POSTGRES_DB: kenketsu_plus_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U kenketsu -d kenketsu_plus_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgres://kenketsu:kenketsu@localhost:5432/kenketsu_plus_test?sslmode=disable
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint format check clean
+.PHONY: build test lint format check clean generate-vapid
 
 build:
 	cd frontend && npm run build
@@ -22,3 +22,6 @@ check: format lint test build
 clean:
 	cd frontend && rm -rf dist/ .next/ coverage/ node_modules/.cache/
 	cd api && go clean -cache -testcache && rm -f coverage.out
+
+generate-vapid:
+	cd api && go run ./cmd/genvapid

--- a/api/cmd/genvapid/main.go
+++ b/api/cmd/genvapid/main.go
@@ -1,0 +1,23 @@
+// Command genvapid generates a WebPush VAPID key pair and prints it as .env
+// assignments, so developers do not need to run an external tool during setup (#24).
+//
+// Usage:
+//
+//	go run ./cmd/genvapid   (or: make generate-vapid)
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/akaitigo/kenketsu-plus/api/internal/vapid"
+)
+
+func main() {
+	keys, err := vapid.GenerateKeys()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to generate VAPID keys:", err)
+		os.Exit(1)
+	}
+	fmt.Print(keys.EnvLines())
+}

--- a/api/internal/repository/center_memory.go
+++ b/api/internal/repository/center_memory.go
@@ -100,8 +100,11 @@ func (r *CenterRepository) Create(_ context.Context, c *model.DonationCenter) (*
 	return c, nil
 }
 
+// earthRadiusKm is the mean radius of the Earth in kilometers, used by the
+// haversine great-circle distance calculation.
+const earthRadiusKm = 6371.0
+
 func haversineKm(lat1, lng1, lat2, lng2 float64) float64 {
-	const earthRadiusKm = 6371.0
 	dLat := degreesToRadians(lat2 - lat1)
 	dLng := degreesToRadians(lng2 - lng1)
 	a := math.Sin(dLat/2)*math.Sin(dLat/2) +

--- a/api/internal/repository/pg_integration_test.go
+++ b/api/internal/repository/pg_integration_test.go
@@ -1,0 +1,251 @@
+package repository_test
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq"
+
+	"github.com/akaitigo/kenketsu-plus/api/internal/model"
+	"github.com/akaitigo/kenketsu-plus/api/internal/repository"
+)
+
+// migrationFiles are applied, in order, to bring a clean schema up to date.
+var migrationFiles = []string{
+	"001_init.sql",
+	"002_push_subscriptions_unique_endpoint.up.sql",
+}
+
+// setupTestDB connects to the PostgreSQL instance named by DATABASE_URL and
+// applies the migrations against a freshly reset schema. The integration tests
+// are skipped when DATABASE_URL is unset (e.g. a plain local `go test`) or when
+// the database is unreachable, mirroring the CI postgres-service pattern (#22).
+func setupTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set; skipping PostgreSQL integration test")
+	}
+
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		t.Skipf("failed to open database (not available): %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		t.Skipf("failed to ping database (not available): %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	resetSchema(t, db)
+	return db
+}
+
+// resetSchema drops the application tables and re-applies all migrations so each
+// test starts from a known, clean state. This is destructive and is intended to
+// run only against a disposable test database.
+func resetSchema(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	ctx := context.Background()
+	if _, err := db.ExecContext(
+		ctx,
+		`DROP TABLE IF EXISTS push_subscriptions, blood_inventory, donations, donation_centers CASCADE`,
+	); err != nil {
+		t.Fatalf("failed to drop tables: %v", err)
+	}
+
+	for _, name := range migrationFiles {
+		path := filepath.Join("..", "..", "migrations", name)
+		content, err := os.ReadFile(path) //nolint:gosec // fixed migration paths, not user input
+		if err != nil {
+			t.Fatalf("failed to read migration %s: %v", name, err)
+		}
+		if _, err := db.ExecContext(ctx, string(content)); err != nil {
+			t.Fatalf("failed to apply migration %s: %v", name, err)
+		}
+	}
+}
+
+func TestPgSubscriptionRepository_UpsertByEndpoint(t *testing.T) {
+	db := setupTestDB(t)
+	repo := repository.NewPgSubscriptionRepository(db)
+	ctx := context.Background()
+
+	first, err := repo.Create(ctx, &model.PushSubscription{
+		Endpoint: "https://push.example.com/sub-a",
+		P256dh:   "key-1",
+		Auth:     "auth-1",
+	})
+	if err != nil {
+		t.Fatalf("first create failed: %v", err)
+	}
+
+	second, err := repo.Create(ctx, &model.PushSubscription{
+		Endpoint: "https://push.example.com/sub-a",
+		P256dh:   "key-2",
+		Auth:     "auth-2",
+	})
+	if err != nil {
+		t.Fatalf("second create (upsert) failed: %v", err)
+	}
+
+	subs := repo.List(ctx)
+	if len(subs) != 1 {
+		t.Fatalf("expected 1 subscription after re-subscribe, got %d", len(subs))
+	}
+	if second.ID != first.ID {
+		t.Errorf("expected stable ID %q across upsert, got %q", first.ID, second.ID)
+	}
+	if subs[0].P256dh != "key-2" || subs[0].Auth != "auth-2" {
+		t.Errorf("expected keys updated to key-2/auth-2, got %s/%s", subs[0].P256dh, subs[0].Auth)
+	}
+}
+
+func TestPgSubscriptions_UniqueConstraintEnforced(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	insert := func() error {
+		_, err := db.ExecContext(
+			ctx,
+			`INSERT INTO push_subscriptions (endpoint, p256dh, auth) VALUES ($1, $2, $3)`,
+			"https://push.example.com/dup", "k", "a",
+		)
+		return err
+	}
+
+	if err := insert(); err != nil {
+		t.Fatalf("first raw insert failed: %v", err)
+	}
+	if err := insert(); err == nil {
+		t.Fatal("expected UNIQUE(endpoint) violation on duplicate insert, got nil")
+	}
+}
+
+func TestPgInventoryRepository_UpdateAndGet(t *testing.T) {
+	db := setupTestDB(t)
+	repo := repository.NewPgInventoryRepository(db)
+	ctx := context.Background()
+
+	updated, err := repo.Update(ctx, model.BloodTypeAPos, model.InventoryLevelCritical)
+	if err != nil {
+		t.Fatalf("update failed: %v", err)
+	}
+	if updated.Level != model.InventoryLevelCritical {
+		t.Errorf("expected level critical, got %s", updated.Level)
+	}
+
+	got, err := repo.GetByBloodType(ctx, model.BloodTypeAPos)
+	if err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+	if got.Level != model.InventoryLevelCritical {
+		t.Errorf("expected persisted level critical, got %s", got.Level)
+	}
+
+	if _, err := repo.Update(ctx, model.BloodType("Z+"), model.InventoryLevelNormal); err == nil {
+		t.Error("expected error for invalid blood type, got nil")
+	}
+}
+
+// TestPgInventoryRepository_NotFound exercises the errors.Is(sql.ErrNoRows) path
+// (#19): updating a valid blood type whose row is missing must return a clear
+// not-found error rather than a raw driver error.
+func TestPgInventoryRepository_NotFound(t *testing.T) {
+	db := setupTestDB(t)
+	repo := repository.NewPgInventoryRepository(db)
+	ctx := context.Background()
+
+	if _, err := db.ExecContext(ctx, `DELETE FROM blood_inventory WHERE blood_type = $1`, string(model.BloodTypeAPos)); err != nil {
+		t.Fatalf("failed to delete inventory row: %v", err)
+	}
+
+	_, err := repo.Update(ctx, model.BloodTypeAPos, model.InventoryLevelCritical)
+	if err == nil {
+		t.Fatal("expected not-found error after deleting inventory row, got nil")
+	}
+}
+
+func TestPgCenterRepository_CRUD(t *testing.T) {
+	db := setupTestDB(t)
+	repo := repository.NewPgCenterRepository(db)
+	ctx := context.Background()
+
+	created, err := repo.Create(ctx, &model.DonationCenter{
+		Name:           "Shibuya Center",
+		Address:        "Shibuya, Tokyo",
+		Lat:            35.6580,
+		Lng:            139.7016,
+		Capacity:       50,
+		AvailableSlots: 10,
+	})
+	if err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+	if created.ID == "" {
+		t.Fatal("expected generated ID")
+	}
+	if created.Status != model.CenterStatusOpen {
+		t.Errorf("expected default status open, got %s", created.Status)
+	}
+
+	fetched, err := repo.GetByID(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("get by id failed: %v", err)
+	}
+	if fetched.Name != "Shibuya Center" {
+		t.Errorf("expected Shibuya Center, got %s", fetched.Name)
+	}
+
+	if all := repo.List(ctx); len(all) != 1 {
+		t.Errorf("expected 1 center, got %d", len(all))
+	}
+
+	near := repo.ListByDistance(ctx, 35.66, 139.70, 5)
+	if len(near) != 1 {
+		t.Errorf("expected 1 center within 5km, got %d", len(near))
+	}
+
+	far := repo.ListByDistance(ctx, 34.6937, 135.5023, 5)
+	if len(far) != 0 {
+		t.Errorf("expected 0 centers within 5km of Osaka, got %d", len(far))
+	}
+}
+
+func TestPgDonationRepository_CreateAndList(t *testing.T) {
+	db := setupTestDB(t)
+	repo := repository.NewPgDonationRepository(db)
+	ctx := context.Background()
+
+	created, err := repo.Create(ctx, &model.Donation{
+		BloodType:    model.BloodTypeOPos,
+		DonationType: model.DonationTypeWhole400,
+		Gender:       model.GenderMale,
+		DonatedAt:    time.Now().UTC().Truncate(time.Second),
+		VolumeMl:     400,
+		Memo:         "integration test",
+	})
+	if err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+	if created.ID == "" {
+		t.Fatal("expected generated ID")
+	}
+
+	list := repo.List(ctx)
+	if len(list) != 1 {
+		t.Fatalf("expected 1 donation, got %d", len(list))
+	}
+	if list[0].BloodType != model.BloodTypeOPos || list[0].Memo != "integration test" {
+		t.Errorf("unexpected donation fields: %+v", list[0])
+	}
+}

--- a/api/internal/service/donation_calculator_test.go
+++ b/api/internal/service/donation_calculator_test.go
@@ -135,6 +135,183 @@ func TestNextAvailableDate_AnnualLimit_Female(t *testing.T) {
 	}
 }
 
+// TestNextAvailableDate_EdgeCases exercises mixed donation-type sequences,
+// annual-limit interactions, boundary values, unsorted input, and unknown types
+// via a table (#23). Day windows are inclusive and allow ±2 slack to absorb
+// time-of-day and timezone effects on the day-count arithmetic.
+func TestNextAvailableDate_EdgeCases(t *testing.T) {
+	t.Parallel()
+
+	calc := service.NewDonationCalculator()
+
+	d := func(dt model.DonationType, g model.Gender, daysAgo int) *model.Donation {
+		return makeDonation(dt, g, time.Now().AddDate(0, 0, -daysAgo))
+	}
+
+	tests := []struct {
+		name          string
+		gender        model.Gender
+		donations     []*model.Donation
+		wantDaysLo    int // asserted only when wantCanDonate is false
+		wantDaysHi    int
+		wantCanDonate bool
+	}{
+		{
+			name: "component after whole400 uses 2-week interval (component is last)",
+			donations: []*model.Donation{
+				d(model.DonationTypeWhole400, model.GenderMale, 20),
+				d(model.DonationTypeComponent, model.GenderMale, 5),
+			},
+			gender:        model.GenderMale,
+			wantCanDonate: false,
+			wantDaysLo:    7,
+			wantDaysHi:    11,
+		},
+		{
+			name: "component to whole400 to component, last component interval expired",
+			donations: []*model.Donation{
+				d(model.DonationTypeComponent, model.GenderMale, 60),
+				d(model.DonationTypeWhole400, model.GenderMale, 40),
+				d(model.DonationTypeComponent, model.GenderMale, 20),
+			},
+			gender:        model.GenderMale,
+			wantCanDonate: true,
+		},
+		{
+			name: "whole400 then component, component still in interval",
+			donations: []*model.Donation{
+				d(model.DonationTypeWhole400, model.GenderMale, 30),
+				d(model.DonationTypeComponent, model.GenderMale, 3),
+			},
+			gender:        model.GenderMale,
+			wantCanDonate: false,
+			wantDaysLo:    9,
+			wantDaysHi:    13,
+		},
+		{
+			name: "male annual whole limit dominates over interval",
+			donations: []*model.Donation{
+				d(model.DonationTypeWhole400, model.GenderMale, 300),
+				d(model.DonationTypeWhole400, model.GenderMale, 200),
+				d(model.DonationTypeWhole400, model.GenderMale, 100),
+			},
+			gender:        model.GenderMale,
+			wantCanDonate: false,
+			wantDaysLo:    62,
+			wantDaysHi:    68,
+		},
+		{
+			name: "whole200 counts toward annual whole limit",
+			donations: []*model.Donation{
+				d(model.DonationTypeWhole200, model.GenderMale, 300),
+				d(model.DonationTypeWhole400, model.GenderMale, 200),
+				d(model.DonationTypeWhole400, model.GenderMale, 100),
+			},
+			gender:        model.GenderMale,
+			wantCanDonate: false,
+			wantDaysLo:    62,
+			wantDaysHi:    68,
+		},
+		{
+			name: "component donations never hit annual limit",
+			donations: []*model.Donation{
+				d(model.DonationTypeComponent, model.GenderMale, 100),
+				d(model.DonationTypeComponent, model.GenderMale, 80),
+				d(model.DonationTypeComponent, model.GenderMale, 60),
+				d(model.DonationTypeComponent, model.GenderMale, 40),
+				d(model.DonationTypeComponent, model.GenderMale, 20),
+			},
+			gender:        model.GenderMale,
+			wantCanDonate: true,
+		},
+		{
+			name: "female annual whole limit is two",
+			donations: []*model.Donation{
+				d(model.DonationTypeWhole400, model.GenderFemale, 200),
+				d(model.DonationTypeWhole400, model.GenderFemale, 100),
+			},
+			gender:        model.GenderFemale,
+			wantCanDonate: false,
+			wantDaysLo:    160,
+			wantDaysHi:    170,
+		},
+		{
+			name: "female single whole400 uses 16-week interval",
+			donations: []*model.Donation{
+				d(model.DonationTypeWhole400, model.GenderFemale, 50),
+			},
+			gender:        model.GenderFemale,
+			wantCanDonate: false,
+			wantDaysLo:    59,
+			wantDaysHi:    65,
+		},
+		{
+			name: "unsorted input still uses the most recent donation",
+			donations: []*model.Donation{
+				d(model.DonationTypeComponent, model.GenderMale, 3),
+				d(model.DonationTypeWhole400, model.GenderMale, 50),
+			},
+			gender:        model.GenderMale,
+			wantCanDonate: false,
+			wantDaysLo:    9,
+			wantDaysHi:    13,
+		},
+		{
+			name: "unknown donation type defaults to 12-week interval",
+			donations: []*model.Donation{
+				d(model.DonationType("unknown"), model.GenderMale, 10),
+			},
+			gender:        model.GenderMale,
+			wantCanDonate: false,
+			wantDaysLo:    71,
+			wantDaysHi:    77,
+		},
+		{
+			name: "boundary just past interval can donate",
+			donations: []*model.Donation{
+				d(model.DonationTypeWhole400, model.GenderMale, 88),
+			},
+			gender:        model.GenderMale,
+			wantCanDonate: true,
+		},
+		{
+			name: "boundary just before interval cannot donate",
+			donations: []*model.Donation{
+				d(model.DonationTypeWhole400, model.GenderMale, 80),
+			},
+			gender:        model.GenderMale,
+			wantCanDonate: false,
+			wantDaysLo:    2,
+			wantDaysHi:    6,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := calc.NextAvailableDate(tt.donations, tt.gender)
+
+			if result.CanDonateToday != tt.wantCanDonate {
+				t.Fatalf("CanDonateToday = %v, want %v (reason: %q, daysRemaining: %d)",
+					result.CanDonateToday, tt.wantCanDonate, result.Reason, result.DaysRemaining)
+			}
+
+			if tt.wantCanDonate {
+				if result.DaysRemaining != 0 {
+					t.Errorf("DaysRemaining = %d, want 0 when donation is possible", result.DaysRemaining)
+				}
+				return
+			}
+
+			if result.DaysRemaining < tt.wantDaysLo || result.DaysRemaining > tt.wantDaysHi {
+				t.Errorf("DaysRemaining = %d, want within [%d, %d]",
+					result.DaysRemaining, tt.wantDaysLo, tt.wantDaysHi)
+			}
+		})
+	}
+}
+
 func TestNextAvailableDate_YearBoundary(t *testing.T) {
 	t.Parallel()
 	calc := service.NewDonationCalculator()

--- a/api/internal/vapid/vapid.go
+++ b/api/internal/vapid/vapid.go
@@ -1,0 +1,33 @@
+// Package vapid provides helpers for generating WebPush VAPID key pairs.
+package vapid
+
+import (
+	"fmt"
+
+	webpush "github.com/SherClockHolmes/webpush-go"
+)
+
+// Keys holds a base64url-encoded VAPID key pair used for WebPush.
+type Keys struct {
+	Public  string
+	Private string
+}
+
+// GenerateKeys creates a new VAPID key pair suitable for WebPush.
+func GenerateKeys() (Keys, error) {
+	private, public, err := webpush.GenerateVAPIDKeys()
+	if err != nil {
+		return Keys{}, fmt.Errorf("generate VAPID keys: %w", err)
+	}
+	return Keys{Public: public, Private: private}, nil
+}
+
+// EnvLines renders the key pair as .env assignments for the API and frontend.
+// The public key is emitted for both the backend (VAPID_PUBLIC_KEY) and the
+// frontend (NEXT_PUBLIC_VAPID_PUBLIC_KEY), which must share the same value.
+func (k Keys) EnvLines() string {
+	return fmt.Sprintf(
+		"VAPID_PUBLIC_KEY=%s\nVAPID_PRIVATE_KEY=%s\nNEXT_PUBLIC_VAPID_PUBLIC_KEY=%s\n",
+		k.Public, k.Private, k.Public,
+	)
+}

--- a/api/internal/vapid/vapid_test.go
+++ b/api/internal/vapid/vapid_test.go
@@ -1,0 +1,56 @@
+package vapid_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/akaitigo/kenketsu-plus/api/internal/vapid"
+)
+
+func TestGenerateKeys(t *testing.T) {
+	t.Parallel()
+
+	keys, err := vapid.GenerateKeys()
+	if err != nil {
+		t.Fatalf("GenerateKeys failed: %v", err)
+	}
+	if keys.Public == "" || keys.Private == "" {
+		t.Fatalf("expected non-empty keys, got public=%q private=%q", keys.Public, keys.Private)
+	}
+	if keys.Public == keys.Private {
+		t.Error("public and private keys must differ")
+	}
+}
+
+func TestGenerateKeys_Unique(t *testing.T) {
+	t.Parallel()
+
+	first, err := vapid.GenerateKeys()
+	if err != nil {
+		t.Fatalf("first GenerateKeys failed: %v", err)
+	}
+	second, err := vapid.GenerateKeys()
+	if err != nil {
+		t.Fatalf("second GenerateKeys failed: %v", err)
+	}
+	if first.Private == second.Private || first.Public == second.Public {
+		t.Error("expected distinct key pairs across calls")
+	}
+}
+
+func TestEnvLines(t *testing.T) {
+	t.Parallel()
+
+	keys := vapid.Keys{Public: "pub-key", Private: "priv-key"}
+	out := keys.EnvLines()
+
+	for _, want := range []string{
+		"VAPID_PUBLIC_KEY=pub-key\n",
+		"VAPID_PRIVATE_KEY=priv-key\n",
+		"NEXT_PUBLIC_VAPID_PUBLIC_KEY=pub-key\n",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("EnvLines output missing %q; got:\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
## 概要
テスト拡充・PostgreSQLインテグレーションテスト・開発体験改善をまとめて対応。

## 変更内容

### #23 (testing) 献血間隔計算のエッジケーステスト拡充
- `TestNextAvailableDate_EdgeCases` をテーブルテストで追加。以下を網羅:
  - 成分→全血→成分の連続パターン（最新の献血種別で間隔判定）
  - 全血後の成分献血（2週間隔に切り替わる）
  - 年間全血上限（男3/女2、全血200mlも計上、成分は非計上）
  - 年間上限が間隔制限を上回るケース
  - 境界値（間隔経過直後は可／直前は不可）
  - 未ソート入力（最新レコードを選択）
  - 未知の献血種別（`default` 分岐 = 12週）

### #22 (testing) PostgreSQL インテグレーションテスト
- `pg_integration_test.go` を追加。`DATABASE_URL` 未設定時は `t.Skip`、設定時は
  schema をリセットして migration（001/002）を適用する urushi-chronicle 実績方式
- CI の api job に `postgres:16-alpine` service + healthcheck + `DATABASE_URL` を組み込み
- 検証内容: subscription UPSERT / UNIQUE制約 / inventory 更新・not-found（#19 の errors.Is 経路）/ center CRUD・距離フィルタ / donation 作成・一覧

### #25 (enhancement) haversine 地球半径の名前付き定数化
- 関数ローカルの `const earthRadiusKm` をパッケージレベル定数に昇格（doc comment 付き）

### #24 (enhancement) VAPID 鍵ペア生成ヘルパー
- `internal/vapid` パッケージ（`GenerateKeys` / `EnvLines`、テスト付き）
- `cmd/genvapid` コマンド（.env 形式で出力）
- `make generate-vapid` target

## ローカル検証
- `go build ./...` OK / `go test -race ./...` 全パス / `golangci-lint run ./...` 0 issues
- `postgres:16-alpine` コンテナに対して integration テスト6件パス（検証後コンテナ停止）
- `actionlint .github/workflows/ci.yml` OK
- `make generate-vapid` で鍵ペア出力を確認

Fixes #23, fixes #22, fixes #25, fixes #24